### PR TITLE
fix: build node_modules into separate docker layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 This is a sample repo showing how to run Docker commands within Nx.
 
 Read up on the companion blog post here.
+
+```bash
+npm run docker:build
+npm run docker:start
+```

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,9 +1,35 @@
 FROM node:lts-alpine
+
+# Where is the app stored in the container
 WORKDIR /app
-COPY ./dist/apps/api .
-ENV PORT=3333
+
+# Set production environment
+ENV NODE_ENV production
+
+# The port that we want to run in the container
+# Google Cloud Run and others override this
+# So it might be better to remove it
+ENV PORT 3333
+
+# Expose the port so that we can reach the app
 EXPOSE ${PORT}
+
+# Copy the package.json only
+COPY package.json ./
+
+# Install dependencies, but skip devDependencies
+# By running npm install in it's own layer, it will be cached
+# So next time if we only change something in the app and not in package.json, docker will only
+# create a new layer with the few new kb that is the app, saving a lot of registry storage
 RUN npm install --production
-# dependencies that nestjs needs
-RUN npm install reflect-metadata tslib rxjs @nestjs/platform-express
-CMD node ./main.js
+
+# When generating the package.json using generatePackageJson
+# It does not copy dependencies that are not specified in imports
+# This is why we need to add them here
+RUN npm install reflect-metadata tslib rxjs @nestjs/platform-express --production
+
+# Copy the built app into /app in the container
+COPY ./dist/apps/api .
+
+# Start the app
+CMD ["node", "main.js"]

--- a/apps/html/Dockerfile
+++ b/apps/html/Dockerfile
@@ -1,8 +1,35 @@
 FROM node:lts-alpine
+
+# Where is the app stored in the container
 WORKDIR /app
-COPY ./dist/apps/html .
-ENV PORT=3334
+
+# Set production environment
+ENV NODE_ENV production
+
+# The port that we want to run in the container
+# Google Cloud Run and others override this
+# So it might be better to remove it
+ENV PORT 3334
+
+# Expose the port so that we can reach the app
 EXPOSE ${PORT}
+
+# Copy the package.json only
+COPY package.json ./
+
+# Install dependencies, but skip devDependencies
+# By running npm install in it's own layer, it will be cached
+# So next time if we only change something in the app and not in package.json, docker will only
+# create a new layer with the few new kb that is the app, saving a lot of registry storage
 RUN npm install --production
-RUN npm install reflect-metadata tslib rxjs @nestjs/platform-express hbs
-CMD node ./main.js
+
+# When generating the package.json using generatePackageJson
+# It does not copy dependencies that are not specified in imports
+# This is why we need to add them here
+RUN npm install reflect-metadata tslib rxjs @nestjs/platform-express --production
+
+# Copy the built app into /app in the container
+COPY ./dist/apps/html .
+
+# Start the app
+CMD ["node", "main.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     environment:
       - apiPath=http://api:3333
     ports:
-      - "8080:3334"
+      - "80:3334"
   api:
     image: api
     ports:
-      - "8081:3333"
+      - "8080:3333"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "license": "MIT",
   "scripts": {
     "nx": "nx",
-    "start": "nx serve",
-    "build": "nx build",
+    "start": "nx run-many --target=serve --projects=api,html --parallel",
+    "build": "nx run-many --target=build --projects=api,html --parallel",
+    "docker:build": "nx run-many --target=deploy --projects=api,html --parallel",
+    "docker:start": "docker-compose up",
     "test": "nx test",
     "lint": "nx workspace-lint && nx lint",
     "e2e": "nx e2e",


### PR DESCRIPTION
To optimize the docker build we want to build as little as possible.
by first installing node_modules and then copying the app and starting it.
We can cache a lot.

the first build took 68s and then since it can cache it only takes 25s.
If we where to enable the nx cloud build, it would drop to < 10s.

I also added some convenience scripts and changes the html port to 80 so you can have the main app run on `http://localhost`

```bash
Sending build context to Docker daemon    287MB
Step 1/10 : FROM node:lts-alpine
 ---> 471e8b4eb0b2
Step 2/10 : WORKDIR /app
 ---> Using cache
 ---> e490029e0f70
Step 3/10 : ENV NODE_ENV production
 ---> Using cache
 ---> 40f401406616
Step 4/10 : ENV PORT 3334
 ---> Using cache
 ---> 187fd4f8b583
Step 5/10 : EXPOSE ${PORT}
 ---> Using cache
 ---> 81f52c510071
Step 6/10 : COPY package.json ./
 ---> Using cache
 ---> 1a20d9abd4e3
Step 7/10 : RUN npm install --production
 ---> Using cache
 ---> b66a3cb03a58
Step 8/10 : RUN npm install reflect-metadata tslib rxjs @nestjs/platform-express --production
 ---> Using cache
 ---> 350dd7802dbd
Step 9/10 : COPY ./dist/apps/html .
 ---> Using cache
 ---> d27c958c2e68
Step 10/10 : CMD ["node", "main.js"]
 ---> Using cache
 ---> 11fdd7a87f6a
Successfully built 11fdd7a87f6a
Successfully tagged html:latest
Sending build context to Docker daemon    287MB
Step 1/10 : FROM node:lts-alpine
 ---> 471e8b4eb0b2
Step 2/10 : WORKDIR /app
 ---> Using cache
 ---> e490029e0f70
Step 3/10 : ENV NODE_ENV production
 ---> Using cache
 ---> 40f401406616
Step 4/10 : ENV PORT 3333
 ---> Using cache
 ---> 81cd12d5da72
Step 5/10 : EXPOSE ${PORT}
 ---> Using cache
 ---> b8f3856dd45d
Step 6/10 : COPY package.json ./
 ---> Using cache
 ---> 65cda8747490
Step 7/10 : RUN npm install --production
 ---> Using cache
 ---> a76d5a5c9860
Step 8/10 : RUN npm install reflect-metadata tslib rxjs @nestjs/platform-express --production
 ---> Using cache
 ---> d24cad6a4250
Step 9/10 : COPY ./dist/apps/api .
 ---> 55b003c33c8a
Step 10/10 : CMD ["node", "main.js"]
 ---> Running in cdf158e5b780
Removing intermediate container cdf158e5b780
 ---> acb3be1e26ea
Successfully built acb3be1e26ea
Successfully tagged api:latest

```